### PR TITLE
Make widget use configured exlcuded status codes

### DIFF
--- a/dashboard-log-monitor.php
+++ b/dashboard-log-monitor.php
@@ -236,7 +236,7 @@ class Dashboard_Log_Monitor_Widget {
         $leftover = "";
 
         // Exclude status codes
-        $exclude_status = self::default_exclude;
+        $exclude_status = self::get_dashboard_widget_option(self::wid, 'exclude_status_codes');
 
         // Remove whitespace and empty values
         $exclude_status = preg_replace('/\s+/', '', $exclude_status);


### PR DESCRIPTION
I added 410 to the status codes to exclude but they still displayed. This is because the code uses the default exclusions regardless of what has been configured.

This fix corrects this by getting the settings.
